### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: continuumio/miniconda3
+
+tasks:
+  - init: conda env create -f environment.yml
+    command: conda activate aspi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,8 @@
 image: continuumio/miniconda3
 
 tasks:
-  - init: conda env create -f environment.yml
+  - init: |
+      # https://github.com/ContinuumIO/docker-images/issues/151
+      conda config --prepend pkgs_dirs $HOME/.conda/pkgs
+      conda env create -f environment.yml
     command: conda activate aspi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # aspi
 *Answer Set Programming, Interactively*
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/davidar/aspi)
 
 This project started as an interactive shell for [clingo](https://github.com/potassco/clingo), and is gradually morphing into an experimental programming language based on [Lambda Dependency-Based Compositional Semantics](https://arxiv.org/abs/1309.4408). It supports a variety of declarative programming paradigms in a cohesive manner:
 


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.